### PR TITLE
chore: bump deco-cx/apps to 0.147.0

### DIFF
--- a/components/ui/CategoryBanner.tsx
+++ b/components/ui/CategoryBanner.tsx
@@ -25,8 +25,8 @@ const DEFAULT_PROPS = {
     banners: [
         {
             image: {
-                mobile: "https://ozksgdmyrqcxcwhnbepg.supabase.co/storage/v1/object/public/assets/239/91102b71-4832-486a-b683-5f7b06f649af",
-                desktop: "https://ozksgdmyrqcxcwhnbepg.supabase.co/storage/v1/object/public/assets/239/ec597b6a-dcf1-48ca-a99d-95b3c6304f96",
+                mobile: "https://decoims.com/investors/d9affe01-28c8-4f40-8e6e-31edd7f077ac/7ee0ee2e45e2e5d4.png",
+                desktop: "https://decoims.com/investors/fcd19909-8909-469a-af55-2ee2fc5a31ee/2cf8c9a31c6df315.png",
                 alt: "a",
             },
             title: "Woman",

--- a/components/ui/Types.ts
+++ b/components/ui/Types.ts
@@ -90,11 +90,11 @@ export const layoutClasses = {
 
 export const imgPh = {
   "sq":
-    "https://ozksgdmyrqcxcwhnbepg.supabase.co/storage/v1/object/public/assets/1818/ff6bb37e-0eab-40e1-a454-86856efc278e",
+    "https://decoims.com/investors/b4c9470d-5506-4fae-8db4-04d283065b4c/331b997080873d67.png",
   "rct-sm":
-    "https://ozksgdmyrqcxcwhnbepg.supabase.co/storage/v1/object/public/assets/1818/b0f8ca2d-9c83-48f7-88de-1a6e6d1e9eb7",
+    "https://decoims.com/investors/625f364b-f1d8-4fd2-86a7-9f5dea96a28f/956fd212ebb6246d.png",
   "rct-lg":
-    "https://ozksgdmyrqcxcwhnbepg.supabase.co/storage/v1/object/public/assets/1818/6fe9404a-f69c-472a-b521-78f6c1f87326",
+    "https://decoims.com/investors/7d042e44-2373-445b-820e-2d3b3e66cc8d/de2e97d647a7a1af.png",
 };
 
 export const colorClasses = {

--- a/constants.tsx
+++ b/constants.tsx
@@ -404,11 +404,11 @@ export const layoutClasses = {
 
 export const imgPh = {
   "sq":
-    "https://ozksgdmyrqcxcwhnbepg.supabase.co/storage/v1/object/public/assets/1818/ff6bb37e-0eab-40e1-a454-86856efc278e",
+    "https://decoims.com/investors/b4c9470d-5506-4fae-8db4-04d283065b4c/331b997080873d67.png",
   "rct-sm":
-    "https://ozksgdmyrqcxcwhnbepg.supabase.co/storage/v1/object/public/assets/1818/b0f8ca2d-9c83-48f7-88de-1a6e6d1e9eb7",
+    "https://decoims.com/investors/625f364b-f1d8-4fd2-86a7-9f5dea96a28f/956fd212ebb6246d.png",
   "rct-lg":
-    "https://ozksgdmyrqcxcwhnbepg.supabase.co/storage/v1/object/public/assets/1818/6fe9404a-f69c-472a-b521-78f6c1f87326",
+    "https://decoims.com/investors/7d042e44-2373-445b-820e-2d3b3e66cc8d/de2e97d647a7a1af.png",
 };
 
 export const colorClasses = {

--- a/deno.json
+++ b/deno.json
@@ -2,7 +2,7 @@
   "imports": {
     "$store/": "./",
     "deco/": "https://cdn.jsdelivr.net/gh/deco-cx/deco@1.106.2/",
-    "apps/": "https://cdn.jsdelivr.net/gh/deco-cx/apps@0.62.6/",
+    "apps/": "https://cdn.jsdelivr.net/gh/deco-cx/apps@0.147.0/",
     "$fresh/": "https://deno.land/x/fresh@1.6.8/",
     "preact": "npm:preact@10.23.1",
     "preact-render-to-string": "npm:preact-render-to-string@6.4.2",

--- a/deno.json
+++ b/deno.json
@@ -2,7 +2,7 @@
   "imports": {
     "$store/": "./",
     "deco/": "https://cdn.jsdelivr.net/gh/deco-cx/deco@1.106.2/",
-    "apps/": "https://cdn.jsdelivr.net/gh/deco-cx/apps@0.147.0/",
+    "apps/": "https://cdn.jsdelivr.net/gh/deco-cx/apps@0.151.1/",
     "$fresh/": "https://deno.land/x/fresh@1.6.8/",
     "preact": "npm:preact@10.23.1",
     "preact-render-to-string": "npm:preact-render-to-string@6.4.2",

--- a/deno.json
+++ b/deno.json
@@ -14,7 +14,27 @@
     "https://esm.sh/*preact-render-to-string@6.3.1": "npm:preact-render-to-string@6.4.2",
     "@deco/deco": "jsr:@deco/deco@1.199.1",
     "@deco/durable": "jsr:@deco/durable@0.5.3",
-    "@deco/dev": "jsr:@deco/dev@1.199.1"
+    "@deco/dev": "jsr:@deco/dev@1.199.1",
+    "@deco/deno-ast-wasm": "jsr:@deco/deno-ast-wasm@0.5.5",
+    "@hono/hono": "jsr:@hono/hono@^4.5.4",
+    "@std/assert": "jsr:@std/assert@^1.0.2",
+    "@std/async": "jsr:@std/async@^0.224.1",
+    "@std/cli": "jsr:@std/cli@^1.0.3",
+    "@std/crypto": "jsr:@std/crypto@1.0.0-rc.1",
+    "@std/datetime": "jsr:@std/datetime@^0.224.0",
+    "@std/encoding": "jsr:@std/encoding@^1.0.0-rc.1",
+    "@std/flags": "jsr:@std/flags@^0.224.0",
+    "@std/fmt": "jsr:@std/fmt@^0.225.3",
+    "@std/fs": "jsr:@std/fs@^0.229.1",
+    "@std/http": "jsr:@std/http@^1.0.0",
+    "@std/io": "jsr:@std/io@^0.224.4",
+    "@std/log": "jsr:@std/log@^0.224.5",
+    "@std/media-types": "jsr:@std/media-types@^1.0.0-rc.1",
+    "@std/path": "jsr:@std/path@^0.225.2",
+    "@std/semver": "jsr:@std/semver@^0.224.3",
+    "@std/streams": "jsr:@std/streams@^1.0.0",
+    "@std/testing": "jsr:@std/testing@^1.0.0",
+    "@core/asyncutil": "jsr:@core/asyncutil@^1.0.2"
   },
   "tasks": {
     "start": "deno run -A --unstable-http --env https://deco.cx/run -- deno task dev",
@@ -52,7 +72,7 @@
       ]
     }
   },
-  "nodeModulesDir": false,
+  "nodeModulesDir": true,
   "compilerOptions": {
     "jsx": "react-jsx",
     "jsxImportSource": "preact",

--- a/deno.json
+++ b/deno.json
@@ -1,9 +1,9 @@
 {
   "imports": {
     "$store/": "./",
-    "deco/": "https://cdn.jsdelivr.net/gh/deco-cx/deco@1.106.2/",
-    "apps/": "https://cdn.jsdelivr.net/gh/deco-cx/apps@0.151.1/",
-    "$fresh/": "https://deno.land/x/fresh@1.6.8/",
+    "deco/": "https://cdn.jsdelivr.net/gh/deco-cx/deco@1.199.1/",
+    "apps/": "https://cdn.jsdelivr.net/gh/deco-cx/apps@0.153.0/",
+    "$fresh/": "https://deno.land/x/fresh@1.7.3/",
     "preact": "npm:preact@10.23.1",
     "preact-render-to-string": "npm:preact-render-to-string@6.4.2",
     "@preact/signals": "https://esm.sh/*@preact/signals@1.2.1",
@@ -12,9 +12,9 @@
     "daisyui": "npm:daisyui@4.6.0",
     "site/": "./",
     "https://esm.sh/*preact-render-to-string@6.3.1": "npm:preact-render-to-string@6.4.2",
-    "@deco/deco": "jsr:@deco/deco@1.106.2",
+    "@deco/deco": "jsr:@deco/deco@1.199.1",
     "@deco/durable": "jsr:@deco/durable@0.5.3",
-    "@deco/dev": "jsr:@deco/dev@1.106.2"
+    "@deco/dev": "jsr:@deco/dev@1.199.1"
   },
   "tasks": {
     "start": "deno run -A --unstable-http --env https://deco.cx/run -- deno task dev",
@@ -31,7 +31,8 @@
     "build": "deno run -A dev.ts build",
     "preview": "deno run -A main.ts",
     "dev": "deno run -A --env --unstable-kv --unstable-hmr dev.ts",
-    "reload": "deno cache -r https://deco.cx/run"
+    "reload": "deno cache -r https://deco.cx/run",
+    "validate": "deno run -A https://deco.cx/validate"
   },
   "githooks": {
     "pre-commit": "check"


### PR DESCRIPTION
Bumps `deco-cx/apps` to [`0.147.0`](https://github.com/deco-cx/apps/releases/tag/0.147.0).

**Release highlight:** _Migrate asset URLs to `decoims.com` (clean cutover, drop `ENABLE_AZION_ASSETS`)._

Opened as a **draft** so CI runs but the PR doesn't auto-merge. If your site uses shared image hosts (assets.decocache.com, deco-assets.edgedeco.com, etc.), this bump migrates those asset URLs to `decoims.com`. Verify image rendering on a preview deployment before marking ready-for-review.

Generated by `scripts/bump-apps-0.147.0/bump.py` (stats-lake repo).