### PR TITLE
chore: migrate legacy image URLs to decoims.com

### DIFF
--- a/.deco/blocks/pages-home-start-5cae41e3d348.json
+++ b/.deco/blocks/pages-home-start-5cae41e3d348.json
@@ -16,27 +16,27 @@
             "href": "https://www.decocms.com/investors-q2-2026"
           },
           {
-            "href": "https://assets.decocache.com/investors/1fa12a76-d26d-4ead-be9e-ef8f716e11ad/2026-01-investor-updates.pdf",
+            "href": "https://decoims.com/investors/012060a8-68b5-49eb-a6ab-cd9141f2d6d4/2026-01-investor-updates.pdf",
             "label": "January 2026 (Q4 2025)"
           },
           {
-            "href": "https://assets.decocache.com/investors/75334a29-10f3-48cd-8d35-c18ca3b70a63/October-13th-2025---Investor-Updates.pdf",
+            "href": "https://decoims.com/investors/7a86b47d-0cbe-42fb-a203-646b623bcf9e/October-13th-2025---Investor-Updates.pdf",
             "label": "October 2025 (Q3 2025)"
           },
           {
-            "href": "https://assets.decocache.com/investors/b3fa564a-9de0-4ed9-a792-ebf0a07720f7/q2-2025.pdf",
+            "href": "https://decoims.com/investors/846ad13c-1052-4d9e-b1a1-c196ee3226b6/q2-2025.pdf",
             "label": "July 2025 (Q2 2025)"
           },
           {
-            "href": "https://assets.decocache.com/investors/0769c027-6f18-4267-8fc7-6158aca13229/q1-2025.pdf",
+            "href": "https://decoims.com/investors/a05d5c5a-5c38-4853-b5ba-c0e85d599e1e/q1-2025.pdf",
             "label": "April 2025 (Q1 2025)"
           },
           {
-            "href": "https://data.decoassets.com/investors/25306d46-055f-492b-ab49-e53dd412d6cb/2025-jan.pdf",
+            "href": "https://decoims.com/investors/8081cc6d-76f2-41ef-afbd-85aff187cc5b/2025-jan.pdf",
             "label": "January 2025 (Q4 2024)"
           },
           {
-            "href": "https://deco-sites-assets.s3.sa-east-1.amazonaws.com/investors/43dd810b-86dd-4e56-a398-038129e85cf8/aug-sep-24.pdf",
+            "href": "https://decoims.com/investors/5fe47673-46f7-4511-a26a-0911d29d8289/aug-sep-24.pdf",
             "label": "August/September 2024"
           },
           {
@@ -105,7 +105,7 @@
       "header": {
         "link": "https://deco.cx",
         "logo": {
-          "img": "https://assets.decocache.com/investors/a2000fd8-33ce-46ce-9b9f-626a6bb505fb/neg-deco-logo.png",
+          "img": "https://decoims.com/investors/5fd9148c-8442-4fcf-a59f-f06cd3a2fb62/neg-deco-logo.png",
           "width": 150,
           "height": 63
         },

--- a/routes/_app.tsx
+++ b/routes/_app.tsx
@@ -27,11 +27,11 @@ export default defineApp(async (_req, ctx) => {
         <link
           rel="icon"
           type="image/png"
-          href="https://assets.decocache.com/investors/a252c16b-0755-45ad-859b-5ebb08a4a64d/neg-d-logo.png"
+          href="https://decoims.com/investors/d87980a9-c147-4dba-9b05-e99138fc6cd3/neg-d-logo.png"
         />
         <link
           rel="apple-touch-icon"
-          href="https://assets.decocache.com/investors/a252c16b-0755-45ad-859b-5ebb08a4a64d/neg-d-logo.png"
+          href="https://decoims.com/investors/d87980a9-c147-4dba-9b05-e99138fc6cd3/neg-d-logo.png"
         />
         <link rel="manifest" href={asset("/site.webmanifest")} />
         <style>{`html, body { background: #070707; margin: 0; padding: 0; }`}</style>


### PR DESCRIPTION
Migração automática de URLs de imagens legadas para decoims.com.

- Substituição de domínios legados (`assets.decocache.com` etc.) por `decoims.com`
- Apenas substituição de strings nos arquivos de configuração/blocos

**Não fazer merge sem revisão.**